### PR TITLE
add simple Histogram Feature

### DIFF
--- a/app/routes/histogram.py
+++ b/app/routes/histogram.py
@@ -1,0 +1,68 @@
+import io
+import base64
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse
+from PIL import Image
+
+from app.config import Configuration
+from app.utils import list_images
+
+router = APIRouter()
+
+def generate_histogram(image_path: str) -> str:
+    """
+    Generate a simple histogram for the given image.
+    The image is converted to grayscale, and a filled histogram is plotted.
+    Returns the plot as a base64 encoded PNG image.
+    """
+    # Open the image in grayscale mode.
+    img = Image.open(image_path).convert("L")
+    # Convert the image to a NumPy array.
+    np_img = np.array(img)
+    # Compute the histogram (256 bins for pixel intensities 0-255).
+    hist, bins = np.histogram(np_img.flatten(), bins=256, range=[0, 256])
+    
+    # Create a simple filled plot.
+    plt.figure(figsize=(8, 4))
+    plt.grid(True, linestyle='--', alpha=0.5)
+    plt.plot(bins[:-1], hist, color='blue', linewidth=2)
+    plt.fill_between(bins[:-1], hist, color='lightblue', alpha=0.5)
+    plt.xlabel("Pixel Intensity")
+    plt.ylabel("Frequency")
+    plt.title("Image Histogram")
+    plt.tight_layout()
+    
+    # Save the figure to a bytes buffer.
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    plt.close()  # Free up memory.
+    buf.seek(0)
+    
+    # Encode the image in base64.
+    img_base64 = base64.b64encode(buf.read()).decode("utf-8")
+    return img_base64
+
+@router.get("/select", response_class=HTMLResponse)
+def get_histogram_form(request: Request):
+    """
+    Render a form that allows the user to select an image for histogram generation.
+    """
+    return request.app.state.templates.TemplateResponse(
+        "histogram_select.html",
+        {"request": request, "images": list_images()}
+    )
+
+@router.post("/select", response_class=HTMLResponse)
+async def show_histogram(request: Request, image_id: str = Form(...)):
+    """
+    Process the selected image, generate its histogram, and display both the original image and the histogram.
+    """
+    image_path = os.path.join(Configuration().image_folder_path, image_id)
+    histogram_img = generate_histogram(image_path)
+    return request.app.state.templates.TemplateResponse(
+        "histogram_output.html",
+        {"request": request, "image_id": image_id, "histogram_img": histogram_img}
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,21 +6,17 @@
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
-    <link rel="shortcut icon" href='static/favicon.ico'">
-
+    <link rel="shortcut icon" href="/static/favicon.ico">
 </head>
 <body>
 
-
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-
         <a class="navbar-brand" href="/">Image Classification</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item active">
@@ -29,29 +25,30 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/classifications">Try it out!</a>
                 </li>
-
+                <!-- New link for the histogram feature -->
+                <li class="nav-item">
+                    <a class="nav-link" href="/histogram/select">Histogram</a>
+                </li>
             </ul>
         </div>
     </div>
 </nav>
 
-
-<div class="container">
+<div class="container mt-4">
     <div class="text-danger font-weight-bold">
-        {% for error in errors %}
-          <li>{{error}}</li>
-        {% endfor %}
-      </div>
-
+        {% if errors %}
+          <ul>
+          {% for error in errors %}
+              <li>{{ error }}</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+    </div>
     {% block content %}
-
-
     {% endblock %}
 </div>
 
-
 <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
 </body>
 </html>

--- a/app/templates/histogram_output.html
+++ b/app/templates/histogram_output.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Image Histogram</h1>
+    <div class="row">
+        <div class="col-md-6">
+            <h3>Original Image</h3>
+            <img src="/static/imagenet_subset/{{ image_id }}" alt="{{ image_id }}" class="img-fluid">
+        </div>
+        <div class="col-md-6">
+            <h3>Histogram</h3>
+            <img src="data:image/png;base64,{{ histogram_img }}" alt="Histogram" class="img-fluid">
+        </div>
+    </div>
+    <a href="/histogram/select" class="btn btn-primary mt-3">Back</a>
+{% endblock %}

--- a/app/templates/histogram_select.html
+++ b/app/templates/histogram_select.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Select Image for Histogram</h1>
+    <form action="/histogram/select" method="post" novalidate>
+        <div class="form-group">
+            <label for="image_id"><strong>Image:</strong></label>
+            <select class="form-control" id="image_id" name="image_id">
+                {% for image in images %}
+                  <option value="{{ image }}">{{ image }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-dark">Submit</button>
+    </form>
+{% endblock %}

--- a/main.py
+++ b/main.py
@@ -3,45 +3,47 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+
 from app.config import Configuration
 from app.forms.classification_form import ClassificationForm
 from app.ml.classification_utils import classify_image
 from app.utils import list_images
 
+# NEW: Import the histogram router
+from app.routes.histogram import router as histogram_router
 
 app = FastAPI()
 config = Configuration()
 
+# Mount static files and configure templates.
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
-
+# Make the templates accessible to all routers (including histogram).
+app.state.templates = templates
 
 @app.get("/info")
 def info() -> dict[str, list[str]]:
-    """Returns a dictionary with the list of models and
-    the list of available image files."""
+    """Return available models and images."""
     list_of_images = list_images()
     list_of_models = Configuration.models
-    data = {"models": list_of_models, "images": list_of_images}
-    return data
-
+    return {"models": list_of_models, "images": list_of_images}
 
 @app.get("/", response_class=HTMLResponse)
 def home(request: Request):
-    """The home page of the service."""
+    """Render the home page."""
     return templates.TemplateResponse("home.html", {"request": request})
-
 
 @app.get("/classifications")
 def create_classify(request: Request):
+    """Render the classification selection page."""
     return templates.TemplateResponse(
         "classification_select.html",
         {"request": request, "images": list_images(), "models": Configuration.models},
     )
 
-
 @app.post("/classifications")
 async def request_classification(request: Request):
+    """Handle image classification requests."""
     form = ClassificationForm(request)
     await form.load_data()
     image_id = form.image_id
@@ -55,3 +57,8 @@ async def request_classification(request: Request):
             "classification_scores": json.dumps(classification_scores),
         },
     )
+
+# NEW: Include the histogram router.
+# The histogram router provides a GET endpoint to display a dropdown for image selection 
+# (similar to the classification form) and a POST endpoint to generate and return the histogram.
+app.include_router(histogram_router, prefix="/histogram")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torchvision
 requests
 Pillow
 python-multipart
+matplotlib


### PR DESCRIPTION
Histogram Feature:

- Added GET/POST endpoints at /histogram/select to let users select an image and view its histogram.
- New templates histogram_select.html and histogram_output.html render the form and display the histogram.
- Generates a simple grayscale histogram using matplotlib and returns it as a base64-encoded PNG.

Navigation & Integration:

- Added a new link in base.html for the histogram page.
- Preserved existing functionality.